### PR TITLE
Allow manually overriding isFirstRun

### DIFF
--- a/src/main/java/net/lopymine/mtd/mixin/MinecraftClientMixin.java
+++ b/src/main/java/net/lopymine/mtd/mixin/MinecraftClientMixin.java
@@ -26,9 +26,9 @@ public class MinecraftClientMixin {
 	@Inject(at = @At("HEAD"), method = "createInitScreens")
 	private void generated(List<Function<Runnable, Screen>> list, CallbackInfo ci) {
 		MyTotemDollConfig config = MyTotemDollClient.getConfig();
-		if (config.isFirstRun() || FabricLoader.getInstance().isDevelopmentEnvironment()) {
+		if (config.isFirstRun()) {
 			list.add(WelcomeScreen::new);
-			config.setFirstRun(false);
+			if (!FabricLoader.getInstance().isDevelopmentEnvironment()) config.setFirstRun(false);
 			config.save();
 		}
 	}


### PR DESCRIPTION
I changed it so it won't update isFirstRun in a development environment, so by default it will still always open the WelcomeScreen, but you can manually edit the config file to override it.