### PR TITLE
conserve CPU cycles by sleeping in busy wait

### DIFF
--- a/src/main/java/net/lopymine/mtd/cache/KnownPlayerUUIDsConfigManager.java
+++ b/src/main/java/net/lopymine/mtd/cache/KnownPlayerUUIDsConfigManager.java
@@ -21,6 +21,7 @@ public class KnownPlayerUUIDsConfigManager {
 					config.save();
 					config.setDirty(false);
 					requestedSave = false;
+					Thread.sleep(2);
 				} catch (Exception e) {
 					MyTotemDollClient.LOGGER.error("Failed to save config:", e);
 				}

--- a/src/main/java/net/lopymine/mtd/cache/KnownPlayerUUIDsConfigManager.java
+++ b/src/main/java/net/lopymine/mtd/cache/KnownPlayerUUIDsConfigManager.java
@@ -11,6 +11,7 @@ public class KnownPlayerUUIDsConfigManager {
 		Thread thread = new Thread(() -> {
 			while (true) {
 				try {
+					Thread.sleep(2);
 					if (!requestedSave) {
 						continue;
 					}
@@ -21,7 +22,6 @@ public class KnownPlayerUUIDsConfigManager {
 					config.save();
 					config.setDirty(false);
 					requestedSave = false;
-					Thread.sleep(2);
 				} catch (Exception e) {
 					MyTotemDollClient.LOGGER.error("Failed to save config:", e);
 				}


### PR DESCRIPTION
in `KnownPlayerUUIDsConfigManager`, it starts up a thread checking for the config and saving it if it's been modified.

it does so by a busy wait, however it consumes so much CPU cycles so a `Thread.sleep` was put there to conserve CPU usage.